### PR TITLE
Fix technical issues in Game of Life

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,8 +29,8 @@ func main() {
 	}
 
 	handler := &app.Handler{
-		Name:        "Conway's Game of Game",
-		Description: "A live demo of Conway's Game of Game.",
+		Name:        "Conway's Game of Life",
+		Description: "A live demo of Conway's Game of Life.",
 		Icon: app.Icon{
 			Default: "/web/logo.png",
 		},

--- a/model/colony.go
+++ b/model/colony.go
@@ -24,7 +24,7 @@ func NewColony(dx, dy int) *Colony {
 
 func (c *Colony) SetCells(cells [][]bool) {
 	c.dy = len(cells)
-	c.dy = len(cells[0])
+	c.dx = len(cells[0])
 	c.cells = &cells
 }
 


### PR DESCRIPTION
- Fix typo: 'Conway's Game of Game' -> 'Conway's Game of Life' in main.go
- Fix bug: Incorrect dy assignment in colony.go SetCells method (should be dx)

These fixes resolve display name errors and potential dimension bugs when loading saved game states.

🤖 Generated with [Claude Code](https://claude.ai/code)